### PR TITLE
[ci] Skeleton of e2e query tests with mysql

### DIFF
--- a/.github/workflows/query-e2e.yml
+++ b/.github/workflows/query-e2e.yml
@@ -1,0 +1,50 @@
+name: Live query execution
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  execute-mysql-queries:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: [3.8]
+    services:
+      postgres:
+        image: genschsa/mysql-employees
+        env:
+          MYSQL_ROOT_PASSWORD: college
+        options: --name mysql-employees -v $PWD/data:/var/lib/mysql
+        ports:
+          - 33060:3306
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install
+      with:
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r compose/requirements.txt
+          python manage.py migrate --noinput
+
+    - name: run tests
+      run: |
+        pytest --cov=compose
+
+    - name: Upload coverage
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: true
+        verbose: true

--- a/compose/editor/sql_alchemy_test.py
+++ b/compose/editor/sql_alchemy_test.py
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from editor.sql_alchemy import SqlAlchemyApi
+
 
 def inc(x):
     return x + 1
@@ -26,3 +28,20 @@ def test_answer():
 
 def test_answer_2():
     assert inc(4) == 5
+
+
+def test_execute_statement():
+    interpreter = {
+        "options": {"url": "sqlite:///../db.sqlite3"},
+        "name": "sqlite",
+        "dialect_properties": {},
+    }
+
+    interpreter = SqlAlchemyApi(None, interpreter=interpreter)
+
+    notebook = {}
+    snippet = {}
+    notebook["sessions"] = []
+    snippet["statement"] = "SELECT 1, 2, 3"
+
+    interpreter.execute(notebook, snippet)


### PR DESCRIPTION
Still need:
- should reuse docker compose probably
- actually sending queries to mysql and not sqlite
- do SqlAlchemy refactoring before
- introduce tag for e2e tests
- only run when Python code changed
- see for Hive, Phoenix etc..