### PR TITLE
[ci] Skeleton of e2e query tests with mysql

### DIFF
--- a/.github/workflows/pyci.yml
+++ b/.github/workflows/pyci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.8]
 
     steps:
     - name: Checkout

--- a/.github/workflows/query-e2e.yml
+++ b/.github/workflows/query-e2e.yml
@@ -1,0 +1,67 @@
+name: Live query execution
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  execute-mysql-queries:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: [3.8]
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ROOT_PASSWORD: password
+        ports:
+          - 13306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    steps:
+
+    - name: Verify MySQL connection from container
+      run: |
+        # Note: mysql or localhost do no work
+        mysql --host 127.0.0.1 --port 13306 -uroot -ppassword -e "SHOW DATABASES"
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Cache pip
+      uses: actions/cache@v2
+      with:
+        # This path is specific to Ubuntu
+        path: ~/.cache/pip
+        # Look to see if there is a cache hit for the corresponding requirements file
+        key: ${{ runner.os }}-pip-${{ hashFiles('compose/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip
+          ${{ runner.os }}
+
+    - name: Install
+      # To move to action, reuse: e.g. install.sh..
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r compose/requirements.txt
+
+    - name: run tests
+      run: |
+        pytest --cov=compose -m live
+
+    - name: Upload coverage
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: true
+        verbose: true

--- a/compose/editor/api.py
+++ b/compose/editor/api.py
@@ -41,7 +41,7 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.decorators import api_view
 
-from editor.sql_alchemy import SqlAlchemyApi
+from .sql_alchemy import SqlAlchemyApi
 
 LOG = logging.getLogger(__name__)
 

--- a/compose/editor/sql_alchemy_test.py
+++ b/compose/editor/sql_alchemy_test.py
@@ -15,6 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
+from compose.editor.sql_alchemy import SqlAlchemyApi
+
 
 def inc(x):
     return x + 1
@@ -26,3 +30,54 @@ def test_answer():
 
 def test_answer_2():
     assert inc(4) == 5
+
+
+@pytest.mark.live
+@pytest.mark.parametrize(("dialect"), [("sqlite")])
+def test_execute_statement(dialect):
+    class User:
+        def __init__(self):
+            self.username = "test"
+
+    interpreter = {
+        "options": {"url": "sqlite:///../db.sqlite3"},
+        "name": "sqlite",
+        "dialect_properties": {},
+    }
+
+    interpreter = SqlAlchemyApi(user=User(), interpreter=interpreter)
+
+    notebook = {}
+    snippet = {}
+    notebook["sessions"] = []
+    snippet["statement"] = "SELECT 1, 2, 3"
+
+    resultset = interpreter.execute(notebook, snippet)
+
+    assert resultset["result"]["data"] == [[1, 2, 3]]
+
+
+# To refactor and parameterize
+@pytest.mark.live
+@pytest.mark.parametrize(("dialect"), [("mysql")])
+def test_execute_statement_mysql(dialect):
+    class User:
+        def __init__(self):
+            self.username = "test"
+
+    interpreter = {
+        "options": {"url": "mysql://root:password@127.0.0.1:13306/mysql"},
+        "name": "mysql",
+        "dialect_properties": {},
+    }
+
+    interpreter = SqlAlchemyApi(user=User(), interpreter=interpreter)
+
+    notebook = {}
+    snippet = {}
+    notebook["sessions"] = []
+    snippet["statement"] = "SELECT 1, 2, 3"
+
+    resultset = interpreter.execute(notebook, snippet)
+
+    assert resultset["result"]["data"] == [[1, 2, 3]]

--- a/compose/requirements.txt
+++ b/compose/requirements.txt
@@ -1,6 +1,4 @@
-asgiref==3.3.1
-coreapi==2.3.3
-Django==3.1.6
+Django==3.1.7
 django-celery-beat==1.4.0
 django-cors-headers==3.7.0
 djangorestframework==3.12.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,8 @@ disable = "C0330, C0326"
 
 [tool.pylint.format]
 max-line-length = "88"
+
+[tool.pytest.ini_options]
+markers = [
+    "live: integration tests executing queries to a live database",
+]


### PR DESCRIPTION
Still need:
- should reuse docker compose probably
- actually sending queries to mysql and not sqlite
- do SqlAlchemy refactoring before
- introduce tag for e2e tests
- only run when Python code changed
- see for Hive, Phoenix etc..